### PR TITLE
Generate certificates, use a password

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,11 @@ RUN pip install ipython[notebook]
 
 EXPOSE 8888
 
-CMD ipython notebook --no-browser --port 8888 --ip=*
+# You can mount your own SSL certs as necessary here
+ENV PEM_FILE /key.pem
+ENV PASSWORD Dont make this your default
+
+ADD notebook.sh /
+RUN chmod u+x /notebook.sh
+
+CMD /notebook.sh

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Docker container for the IPython notebook (single user).
 Assuming you have docker installed, run this to start up a notebook server on port 8888:
 
 ```
-docker run -d -p 8888:8888 ipython/notebook
+docker run -d -p localhost:8888:8888 ipython/notebook
 ```
+
+Make sure to access it at "https://localhost:8888"
 
 ## Hacking on the Dockerfile
 

--- a/notebook.sh
+++ b/notebook.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Strict mode
+set -euo pipefail
+IFS=$'\n\t' 
+
+# Create a self signed certificate for the user if one doesn't exist
+if [ ! -f $PEM_FILE ]; then
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $PEM_FILE -out $PEM_FILE \
+    -subj "/C=XX/ST=XX/L=XX/O=dockergenerated/CN=dockergenerated"
+fi
+
+HASH=$(python -c "from IPython.lib import passwd; print(passwd('${PASSWORD}'))")
+unset PASSWORD
+
+ipython notebook --no-browser --port 8888 --ip=* --certfile=$PEM_FILE --NotebookApp.password="$HASH"


### PR DESCRIPTION
It bothers me to set people up with this docker container and not use an encrypted connection by default. This establishes a certificate at runtime and accepts a password:

```
docker run -p 8888:8888 -e PASSWORD=GreatPassword ipython/notebook
```

With some modification, this could accept a user's certificate too.

We'll have to (want to?) handle https://github.com/tornadoweb/tornado/issues/523 directly though to let HTTP redirect to HTTPS. Would packaging nginx+conf in here make sense?
