### PR TITLE
Stick the args to CMD in a list. Fixes #3.

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -15,4 +15,4 @@ ENV PASSWORD Dont make this your default
 ADD notebook.sh /
 RUN chmod u+x /notebook.sh
 
-CMD /notebook.sh
+CMD ["/notebook.sh"]

--- a/scipyserver/Dockerfile
+++ b/scipyserver/Dockerfile
@@ -15,4 +15,4 @@ ENV PASSWORD Dont make this your default
 ADD notebook.sh /
 RUN chmod u+x /notebook.sh
 
-CMD /notebook.sh
+CMD ["/notebook.sh"]


### PR DESCRIPTION
Well, I finally figured out what was going on with slow shell access (#3). It was all about how the Dockerfile was laid out.

```
CMD /notebook.sh
```

is very different from

```
CMD ["/notebook.sh"]
```

From the [section on `CMD` in the Docker docs](https://docs.docker.com/reference/builder/#cmd):

> If you use the shell form of the `CMD`, then the `<command>` will execute in `/bin/sh -c`

Switching over made the timings sane.
