### PR TITLE
Default to Python 3

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -23,3 +23,4 @@ RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python
 RUN apt-get install -y -q python python-dev python-pip
 
 RUN pip3 install ipython[all]
+RUN pip2 install ipython[all]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -17,8 +17,6 @@ RUN dpkg-reconfigure locales
 
 # Python binary dependencies, developer tools
 RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python3-dev python3-pip  && \
-    apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libcurl4-openssl-dev nodejs && \
-    apt-get autoremove -y --purge && \
-    apt-get clean -y
+    apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libcurl4-openssl-dev nodejs
 
 RUN pip3 install ipython[all]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,7 +16,10 @@ RUN locale-gen en_US.UTF-8
 RUN dpkg-reconfigure locales
 
 # Python binary dependencies, developer tools
-RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python3-dev python3-pip  && \
+RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python3-dev python3-pip && \
     apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libcurl4-openssl-dev nodejs
+
+# Install Python 2.x as well
+RUN apt-get install -y -q python python-dev python-pip
 
 RUN pip3 install ipython[all]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,24 +1,24 @@
 FROM ubuntu:14.04
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
- 
+
 # Make sure apt is up to date
 RUN apt-get update
 RUN apt-get upgrade -y
- 
+
 # Not essential, but wise to set the lang
 RUN apt-get install -y language-pack-en
 ENV LANGUAGE en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
- 
+
 RUN locale-gen en_US.UTF-8
 RUN dpkg-reconfigure locales
 
 # Python binary dependencies, developer tools
-RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python3-dev python3-pip python python-dev python-pip && \
+RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python3-dev python3-pip  && \
     apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libcurl4-openssl-dev nodejs && \
     apt-get autoremove -y --purge && \
     apt-get clean -y
 
-RUN pip install ipython[all]
+RUN pip3 install ipython[all]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,7 +16,7 @@ RUN locale-gen en_US.UTF-8
 RUN dpkg-reconfigure locales
 
 # Python binary dependencies, developer tools
-RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python python-dev python-pip && \
+RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python3-dev python3-pip python python-dev python-pip && \
     apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libcurl4-openssl-dev nodejs && \
     apt-get autoremove -y --purge && \
     apt-get clean -y

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,5 +22,12 @@ RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python
 # Install Python 2.x as well
 RUN apt-get install -y -q python python-dev python-pip
 
+# Install IPython for Python 3 and 2
+# Let IPython for Python 2 win as the default `ipython`
 RUN pip3 install ipython[all]
 RUN pip2 install ipython[all]
+
+# Register each kernel
+# This will be applied when IPython 3.0 comes out
+#RUN ipython2 kernelspec install-self
+#RUN ipython3 kernelspec install-self

--- a/notebook/notebook.sh
+++ b/notebook/notebook.sh
@@ -12,7 +12,7 @@ fi
 
 # Create the hash to pass to the IPython notebook, but don't export it so it doesn't appear
 # as an environment variable within IPython kernels themselves
-HASH=$(python -c "from IPython.lib import passwd; print(passwd('${PASSWORD}'))")
+HASH=$(python3 -c "from IPython.lib import passwd; print(passwd('${PASSWORD}'))")
 unset PASSWORD
 
 ipython notebook --no-browser --port 8888 --ip=* --certfile=$PEM_FILE --NotebookApp.password="$HASH"

--- a/scipyserver/notebook.sh
+++ b/scipyserver/notebook.sh
@@ -15,4 +15,4 @@ fi
 HASH=$(python3 -c "from IPython.lib import passwd; print(passwd('${PASSWORD}'))")
 unset PASSWORD
 
-ipython notebook --no-browser --port 8888 --ip=* --certfile=$PEM_FILE --NotebookApp.password="$HASH"
+ipython2 notebook --no-browser --port 8888 --ip=* --certfile=$PEM_FILE --NotebookApp.password="$HASH"

--- a/scipyserver/notebook.sh
+++ b/scipyserver/notebook.sh
@@ -12,7 +12,7 @@ fi
 
 # Create the hash to pass to the IPython notebook, but don't export it so it doesn't appear
 # as an environment variable within IPython kernels themselves
-HASH=$(python -c "from IPython.lib import passwd; print(passwd('${PASSWORD}'))")
+HASH=$(python3 -c "from IPython.lib import passwd; print(passwd('${PASSWORD}'))")
 unset PASSWORD
 
 ipython notebook --no-browser --port 8888 --ip=* --certfile=$PEM_FILE --NotebookApp.password="$HASH"

--- a/scipystack/Dockerfile
+++ b/scipystack/Dockerfile
@@ -13,5 +13,5 @@ ADD build_scipy_stack.sh build_scipy_stack.sh
 RUN bash build_scipy_stack.sh
 
 ## Extremely basic test of install
-RUN python3 -c "import matplotlib, scipy, numpy, pandas"
-RUN python3 -c "import sklearn, seaborn, yt, patsy, sympy"
+#RUN python2 -c "import matplotlib, scipy, numpy, pandas, sklearn, seaborn, yt, patsy, sympy, IPython, statsmodels"
+#RUN python3 -c "import matplotlib, scipy, numpy, pandas, sklearn, seaborn, yt, patsy, sympy, IPython"

--- a/scipystack/Dockerfile
+++ b/scipystack/Dockerfile
@@ -1,18 +1,17 @@
 FROM ipython/base
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
- 
-RUN apt-get build-dep -y python python-scipy python-matplotlib cython python-h5py && \
-  easy_install -U distribute && \
-  pip install -U Cython && \
-  pip install numpy scipy pandas matplotlib scikit-learn && \
-  pip install patsy && \
-  pip install statsmodels && \
-  pip install seaborn && \
-  pip install yt && \
-  pip install sympy && \
-  pip install h5py
+
+RUN apt-get build-dep -y python3 python3-scipy python3-matplotlib cython3 python3-h5py && \
+  pip3 install -U Cython && \
+  pip3 install numpy scipy pandas matplotlib scikit-learn && \
+  pip3 install patsy && \
+  pip3 install statsmodels && \
+  pip3 install seaborn && \
+  pip3 install yt && \
+  pip3 install sympy && \
+  pip3 install h5py
 
 # Extremely basic test of install
-RUN python -c "import matplotlib, scipy, numpy, pandas"
-RUN python -c "import sklearn, seaborn, statsmodels, yt, patsy, sympy"
+RUN python3 -c "import matplotlib, scipy, numpy, pandas"
+RUN python3 -c "import sklearn, seaborn, statsmodels, yt, patsy, sympy"

--- a/scipystack/Dockerfile
+++ b/scipystack/Dockerfile
@@ -2,20 +2,17 @@ FROM ipython/base
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
 
-RUN apt-get build-dep -y python3 python3-numpy python3-scipy python3-matplotlib cython3 python3-h5py && \
-  apt-get install -y build-essential python3-dev && \
-  pip3 install -U Cython && \
-  pip3 install numpy scipy && \
-  pip3 install pandas scikit-learn
+# From https://github.com/ogrisel/docker-openblas
+ADD https://raw.githubusercontent.com/ogrisel/docker-openblas/master/openblas.conf /etc/ld.so.conf.d/openblas.conf
 
-RUN pip3 install matplotlib && \
-  pip3 install patsy && \
-  pip3 install statsmodels && \
-  pip3 install seaborn && \
-  pip3 install yt && \
-  pip3 install sympy && \
-  pip3 install h5py
+# From https://github.com/ogrisel/docker-sklearn-openblas
+ADD https://raw.githubusercontent.com/ogrisel/docker-sklearn-openblas/master/numpy-site.cfg numpy-site.cfg
+ADD https://raw.githubusercontent.com/ogrisel/docker-sklearn-openblas/master/scipy-site.cfg scipy-site.cfg
+ADD https://raw.githubusercontent.com/ogrisel/docker-sklearn-openblas/master/build_sklearn.sh build_sklearn.sh
 
-# Extremely basic test of install
+ADD build_scipy_stack.sh build_scipy_stack.sh
+RUN bash build_scipy_stack.sh
+
+## Extremely basic test of install
 RUN python3 -c "import matplotlib, scipy, numpy, pandas"
-RUN python3 -c "import sklearn, seaborn, statsmodels, yt, patsy, sympy"
+RUN python3 -c "import sklearn, seaborn, yt, patsy, sympy"

--- a/scipystack/Dockerfile
+++ b/scipystack/Dockerfile
@@ -2,9 +2,13 @@ FROM ipython/base
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
 
-RUN apt-get build-dep -y python3 python3-scipy python3-matplotlib cython3 python3-h5py && \
+RUN apt-get build-dep -y python3 python3-numpy python3-scipy python3-matplotlib cython3 python3-h5py && \
+  apt-get install -y build-essential python3-dev && \
   pip3 install -U Cython && \
-  pip3 install numpy scipy pandas matplotlib scikit-learn && \
+  pip3 install numpy scipy && \
+  pip3 install pandas scikit-learn
+
+RUN pip3 install matplotlib && \
   pip3 install patsy && \
   pip3 install statsmodels && \
   pip3 install seaborn && \

--- a/scipystack/Dockerfile
+++ b/scipystack/Dockerfile
@@ -13,5 +13,5 @@ ADD build_scipy_stack.sh build_scipy_stack.sh
 RUN bash build_scipy_stack.sh
 
 ## Extremely basic test of install
-#RUN python2 -c "import matplotlib, scipy, numpy, pandas, sklearn, seaborn, yt, patsy, sympy, IPython, statsmodels"
-#RUN python3 -c "import matplotlib, scipy, numpy, pandas, sklearn, seaborn, yt, patsy, sympy, IPython"
+RUN python2 -c "import matplotlib, scipy, numpy, pandas, sklearn, seaborn, yt, patsy, sympy, IPython, statsmodels"
+RUN python3 -c "import matplotlib, scipy, numpy, pandas, sklearn, seaborn, yt, patsy, sympy, IPython"

--- a/scipystack/Dockerfile
+++ b/scipystack/Dockerfile
@@ -15,3 +15,6 @@ RUN bash build_scipy_stack.sh
 ## Extremely basic test of install
 RUN python2 -c "import matplotlib, scipy, numpy, pandas, sklearn, seaborn, yt, patsy, sympy, IPython, statsmodels"
 RUN python3 -c "import matplotlib, scipy, numpy, pandas, sklearn, seaborn, yt, patsy, sympy, IPython"
+
+# Clean up from build
+RUN rm -f /build_scipy_stack.sh /numpy-site.cfg /scipy-site.cfg

--- a/scipystack/Dockerfile
+++ b/scipystack/Dockerfile
@@ -3,12 +3,11 @@ FROM ipython/base
 MAINTAINER IPython Project <ipython-dev@scipy.org>
 
 # From https://github.com/ogrisel/docker-openblas
-ADD https://raw.githubusercontent.com/ogrisel/docker-openblas/master/openblas.conf /etc/ld.so.conf.d/openblas.conf
+ADD openblas.conf /etc/ld.so.conf.d/openblas.conf
 
 # From https://github.com/ogrisel/docker-sklearn-openblas
-ADD https://raw.githubusercontent.com/ogrisel/docker-sklearn-openblas/master/numpy-site.cfg numpy-site.cfg
-ADD https://raw.githubusercontent.com/ogrisel/docker-sklearn-openblas/master/scipy-site.cfg scipy-site.cfg
-ADD https://raw.githubusercontent.com/ogrisel/docker-sklearn-openblas/master/build_sklearn.sh build_sklearn.sh
+ADD numpy-site.cfg numpy-site.cfg
+ADD scipy-site.cfg scipy-site.cfg
 
 ADD build_scipy_stack.sh build_scipy_stack.sh
 RUN bash build_scipy_stack.sh

--- a/scipystack/README.md
+++ b/scipystack/README.md
@@ -9,6 +9,5 @@ Relies on `ipython/base`, installs the [SciPy stack](http://www.scipy.org/stacks
 * scikit-learn
 * scipy
 * seaborn
-* statsmodels
 * sympy
 * yt

--- a/scipystack/build_scipy_stack.sh
+++ b/scipystack/build_scipy_stack.sh
@@ -41,6 +41,7 @@ for PYTHONVER in 2 3 ; do
   (cd numpy && $PYTHON setup.py install)
   (cd scipy && $PYTHON setup.py install)
   
+  # The rest of the SciPy Stack
   $PIP install cython
   $PIP install pandas scikit-learn
   $PIP install matplotlib

--- a/scipystack/build_scipy_stack.sh
+++ b/scipystack/build_scipy_stack.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Build OpenBLAS and clean up build dependencies
+set -xe
+
+mkdir /tmp/build
+cd /tmp/build
+
+apt-get -y update
+apt-get -y install git-core build-essential gfortran python3-dev curl
+
+# Build latest stable release from OpenBLAS from source
+git clone -q --branch=master git://github.com/xianyi/OpenBLAS.git
+(cd OpenBLAS \
+      && make DYNAMIC_ARCH=1 NO_AFFINITY=1 NUM_THREADS=32 \
+          && make install)
+
+# Rebuild ld cache, this assumes that:
+# /etc/ld.so.conf.d/openblas.conf was installed by Dockerfile
+# and that the libraries are in /opt/OpenBLAS/lib
+ldconfig
+
+# System dependencies
+apt-get build-dep -y python3 python3-numpy python3-scipy python3-matplotlib cython3 python3-h5py
+apt-get install -y build-essential python3-dev
+curl https://bootstrap.pypa.io/get-pip.py | python3
+pip3 install cython
+
+# Build NumPy and SciPy from source against OpenBLAS installed
+git clone -q --branch=v1.9.0 git://github.com/numpy/numpy.git
+cp /numpy-site.cfg numpy/site.cfg
+(cd numpy && python3 setup.py install)
+
+git clone -q --branch=v0.14.0 git://github.com/scipy/scipy.git
+cp /scipy-site.cfg scipy/site.cfg
+(cd scipy && python3 setup.py install)
+
+pip3 install pandas scikit-learn
+pip3 install matplotlib
+pip3 install seaborn
+pip3 install h5py
+pip3 install yt
+pip3 install sympy
+pip3 install patsy
+
+# Reduce the image size
+apt-get autoremove -y
+apt-get clean -y
+
+cd /
+rm -rf /tmp/build
+rm -rf /build_openblas.sh

--- a/scipystack/build_scipy_stack.sh
+++ b/scipystack/build_scipy_stack.sh
@@ -52,6 +52,9 @@ for PYTHONVER in 2 3 ; do
   $PIP install patsy
 done
 
+# Only Python 2 gets statsmodels until their next release
+pip2 install statsmodels
+
 # Reduce the image size
 apt-get autoremove -y
 apt-get clean -y

--- a/scipystack/build_scipy_stack.sh
+++ b/scipystack/build_scipy_stack.sh
@@ -61,4 +61,3 @@ apt-get clean -y
 
 cd /
 rm -rf /tmp/build
-rm -rf /build_openblas.sh

--- a/scipystack/build_scipy_stack.sh
+++ b/scipystack/build_scipy_stack.sh
@@ -23,25 +23,33 @@ ldconfig
 # System dependencies
 apt-get build-dep -y python3 python3-numpy python3-scipy python3-matplotlib cython3 python3-h5py
 apt-get install -y build-essential python3-dev
-curl https://bootstrap.pypa.io/get-pip.py | python3
-pip3 install cython
 
-# Build NumPy and SciPy from source against OpenBLAS installed
 git clone -q --branch=v1.9.0 git://github.com/numpy/numpy.git
 cp /numpy-site.cfg numpy/site.cfg
-(cd numpy && python3 setup.py install)
 
 git clone -q --branch=v0.14.0 git://github.com/scipy/scipy.git
 cp /scipy-site.cfg scipy/site.cfg
-(cd scipy && python3 setup.py install)
 
-pip3 install pandas scikit-learn
-pip3 install matplotlib
-pip3 install seaborn
-pip3 install h5py
-pip3 install yt
-pip3 install sympy
-pip3 install patsy
+curl https://bootstrap.pypa.io/get-pip.py | python2
+curl https://bootstrap.pypa.io/get-pip.py | python3
+
+for PYTHONVER in 2 3 ; do
+  PYTHON="python$PYTHONVER"
+  PIP="pip$PYTHONVER"
+
+  # Build NumPy and SciPy from source against OpenBLAS installed
+  (cd numpy && $PYTHON setup.py install)
+  (cd scipy && $PYTHON setup.py install)
+  
+  $PIP install cython
+  $PIP install pandas scikit-learn
+  $PIP install matplotlib
+  $PIP install seaborn
+  $PIP install h5py
+  $PIP install yt
+  $PIP install sympy
+  $PIP install patsy
+done
 
 # Reduce the image size
 apt-get autoremove -y

--- a/scipystack/numpy-site.cfg
+++ b/scipystack/numpy-site.cfg
@@ -1,0 +1,4 @@
+[openblas]
+libraries = openblas
+library_dirs = /opt/OpenBLAS/lib
+include_dirs = /opt/OpenBLAS/include

--- a/scipystack/openblas.conf
+++ b/scipystack/openblas.conf
@@ -1,0 +1,1 @@
+/opt/OpenBLAS/lib

--- a/scipystack/scipy-site.cfg
+++ b/scipystack/scipy-site.cfg
@@ -1,0 +1,9 @@
+[DEFAULT]
+library_dirs = /opt/OpenBLAS/lib:/usr/local/lib
+include_dirs = /opt/OpenBLAS/include:/usr/local/include
+
+[blas_opt]
+libraries = openblas
+
+[lapack_opt]
+libraries = openblas


### PR DESCRIPTION
In support of #8.

Right now I've just installed it and I'm trying to understand the right way to default to python3. There is the option of symlinking both `python` and `pip`.
