### PR TITLE
Suggest binding to 443 to ease workflow for people

### DIFF
--- a/notebook/README.md
+++ b/notebook/README.md
@@ -5,13 +5,13 @@ Docker container for the IPython notebook (single user).
 
 ## Quickstart
 
-Assuming you have docker installed, run this to start up a notebook server on port 8888:
+Assuming you have docker installed, run this to start up a notebook server over HTTPS.
 
 ```
-docker run -d -p 8888:8888 -e "PASSWORD=MakeAPassword" ipython/notebook
+docker run -d -p 443:8888 -e "PASSWORD=MakeAPassword" ipython/notebook
 ```
 
-You'll now be able to access your notebook at https://localhost:8888 with password MakeAPassword (please change the environment variable above).
+You'll now be able to access your notebook at https://localhost with password MakeAPassword (please change the environment variable above).
 
 ## Hacking on the Dockerfile
 
@@ -19,5 +19,17 @@ Clone this repository, make changes then build the container:
 
 ```
 docker build -t notebook .
-docker run -d -p 8888:8888 -e "PASSWORD=MakeAPassword" notebook
+docker run -d -p 443:8888 -e "PASSWORD=MakeAPassword" notebook
 ```
+
+## Use your own certificate
+This image looks for `/key.pem`. If it doesn't exist a self signed certificate will be made. If you would like to use your own certificate, concatenate your private and public key along with possible intermediate certificates in a pem file. The order should be (top to bottom): key, certificate, intermediate certificate.
+
+Example:
+```
+cat hostname.key hostname.pub.cert intermidiate.cert > hostname.pem
+```
+
+Then you would mount this file to the docker container:
+```
+docker run -v /path/to/hostname.pem:/key.pem -d -p 443:8888 -e "PASSWORD=pass" ipython/scipyserver

--- a/scipyserver/README.md
+++ b/scipyserver/README.md
@@ -5,13 +5,13 @@ Docker container for the [SciPy stack](../scipystack) and configured IPython not
 
 ## Quickstart
 
-Assuming you have docker installed, run this to start up a notebook server on port 8888:
+Assuming you have docker installed, run this to start up a notebook server on https://localhost.
 
 ```
-docker run -d -p 8888:8888 -e "PASSWORD=MakeAPassword" ipython/scipyserver
+docker run -d -p 443:8888 -e "PASSWORD=MakeAPassword" ipython/scipyserver
 ```
 
-You'll now be able to access your notebook at https://localhost:8888 with password MakeAPassword (please change the environment variable above).
+You'll now be able to access your notebook at https://localhost with password MakeAPassword (please change the environment variable above).
 
 ## Hacking on the Dockerfile
 
@@ -19,11 +19,11 @@ Clone this repository, make changes then build the container:
 
 ```
 docker build -t scipyserver .
-docker run -d -p 8888:8888 -e "PASSWORD=MakeAPassword" scipyserver
+docker run -d -p 443:8888 -e "PASSWORD=MakeAPassword" scipyserver
 ```
 
 ## Use your own certificate
-IPython notebook looks for /key.pem, if it doesn't exists a self signed certificate will be made. If you would like to use your own certificate, concatenate your private and public key along with possible intermediate certificates in a pem file. The order should be (top to bottom): key, certificate, intermediate certificate.
+This image looks for `/key.pem`. If it doesn't exist a self signed certificate will be made. If you would like to use your own certificate, concatenate your private and public key along with possible intermediate certificates in a pem file. The order should be (top to bottom): key, certificate, intermediate certificate.
 
 Example:
 ```
@@ -32,5 +32,5 @@ cat hostname.key hostname.pub.cert intermidiate.cert > hostname.pem
 
 Then you would mount this file to the docker container:
 ```
-docker run -v /path/to/hostname.pem:/key.pem ipython/scipyserver
+docker run -v /path/to/hostname.pem:/key.pem -d -p 443:8888 -e "PASSWORD=pass" ipython/scipyserver
 ```


### PR DESCRIPTION
Someone commented [on the Docker image itself](https://registry.hub.docker.com/u/ipython/notebook/) (scroll to the bottom) saying that it may make more sense to just bind to 443 via Docker and have people navigate to [https://localhost](https://localhost).
