### PR TITLE
npm, nodejs-legacy, less

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -17,7 +17,9 @@ RUN dpkg-reconfigure locales
 
 # Python binary dependencies, developer tools
 RUN apt-get install -y -q build-essential make gcc zlib1g-dev git python3 python3-dev python3-pip && \
-    apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libcurl4-openssl-dev nodejs
+    apt-get install -y -q libzmq3-dev sqlite3 libsqlite3-dev pandoc libcurl4-openssl-dev nodejs nodejs-legacy npm
+
+RUN npm install -g less
 
 # Install Python 2.x as well
 RUN apt-get install -y -q python python-dev python-pip


### PR DESCRIPTION
Install:
- nodejs-legacy
- npm
- less

To make building IPython from source easy on top of base.
