### PR TITLE
Added option for using HTTP

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -11,6 +11,7 @@ EXPOSE 8888
 ENV PEM_FILE /key.pem
 # $PASSWORD will get `unset` within notebook.sh, turned into an IPython style hash
 ENV PASSWORD Dont make this your default
+ENV USE_HTTP 0
 
 ADD notebook.sh /
 RUN chmod u+x /notebook.sh

--- a/notebook/README.md
+++ b/notebook/README.md
@@ -33,3 +33,12 @@ cat hostname.key hostname.pub.cert intermidiate.cert > hostname.pem
 Then you would mount this file to the docker container:
 ```
 docker run -v /path/to/hostname.pem:/key.pem -d -p 443:8888 -e "PASSWORD=pass" ipython/scipyserver
+
+## Using HTTP
+This docker image by default runs IPython notebook in HTTPS.  If you'd like to run this in HTTP,
+you can use the `USE_HTTP` environment variable.  Setting it to a non-zero value enables HTTP.
+
+Example:
+```
+docker run -d -p 443:8888 -e "PASSWORD=MakeAPassword" -e "USE_HTTP=1" ipython/notebook
+```

--- a/notebook/notebook.sh
+++ b/notebook/notebook.sh
@@ -15,4 +15,10 @@ fi
 HASH=$(python3 -c "from IPython.lib import passwd; print(passwd('${PASSWORD}'))")
 unset PASSWORD
 
-ipython notebook --no-browser --port 8888 --ip=* --certfile=$PEM_FILE --NotebookApp.password="$HASH"
+CERTFILE_OPTION="--certfile=$PEM_FILE"
+
+if [ $USE_HTTP -ne 0 ]; then
+  CERTFILE_OPTION=""
+fi
+
+ipython notebook --no-browser --port 8888 --ip=* $CERTFILE_OPTION --NotebookApp.password="$HASH"


### PR DESCRIPTION
Added option in the `Dockerfile` and in `notebook.sh` to use HTTP instead of HTTPS for IPython notebook.  Let me know if this is something you guys are interested in adding and I'll add a note about this option to the docs.

Thanks for building this!
