### PR TITLE
Pin to ipython/ipython:3.x

### DIFF
--- a/notebook/Dockerfile
+++ b/notebook/Dockerfile
@@ -1,4 +1,4 @@
-FROM ipython/ipython
+FROM ipython/ipython:3.x
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
 

--- a/scipystack/Dockerfile
+++ b/scipystack/Dockerfile
@@ -1,4 +1,4 @@
-FROM ipython/ipython
+FROM ipython/ipython:3.x
 
 MAINTAINER IPython Project <ipython-dev@scipy.org>
 


### PR DESCRIPTION
Since the Big Split™ is happening on master in ipython/ipython, we should pin down the images that people are relying on here. This makes all the derivative images of ipython/ipython use `ipython/ipython:3.x` from Docker Hub.
