### PR TITLE
Update notebook.sh

### DIFF
--- a/scipyserver/notebook.sh
+++ b/scipyserver/notebook.sh
@@ -4,21 +4,21 @@
 set -euo pipefail
 IFS=$'\n\t' 
 
-# Create a self signed certificate for the user if one doesn't exist
-if [ ! -f $PEM_FILE ]; then
-  openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $PEM_FILE -out $PEM_FILE \
-    -subj "/C=XX/ST=XX/L=XX/O=dockergenerated/CN=dockergenerated"
-fi
-
 # Create the hash to pass to the IPython notebook, but don't export it so it doesn't appear
 # as an environment variable within IPython kernels themselves
 HASH=$(python3 -c "from IPython.lib import passwd; print(passwd('${PASSWORD}'))")
 unset PASSWORD
 
-CERTFILE_OPTION="--certfile=$PEM_FILE"
-
 if [ $USE_HTTP -ne 0 ]; then
   CERTFILE_OPTION=""
+else
+  # Create a self signed certificate for the user if one doesn't exist
+  if [ ! -f $PEM_FILE ]; then
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout $PEM_FILE -out $PEM_FILE \
+      -subj "/C=XX/ST=XX/L=XX/O=dockergenerated/CN=dockergenerated"
+  fi
+
+  CERTFILE_OPTION="--certfile=$PEM_FILE"
 fi
 
 ipython2 notebook --no-browser --port 8888 --ip=* $CERTFILE_OPTION --NotebookApp.password="$HASH" --matplotlib=inline


### PR DESCRIPTION
Fixes #43: Do not generate PEM_FILE when USE_HTTP=1 (i.e., no HTTPS support requested).
