### PR TITLE
Adds an onbuild-variant for notebook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-images: scipyserver notebook scipystack
+images: scipyserver notebook notebook-onbuild scipystack
 
 pull:
 	docker pull ipython/ipython
@@ -6,10 +6,13 @@ pull:
 notebook: notebook/Dockerfile
 		docker build -t ipython/notebook notebook
 
+notebook-onbuild: notebook
+		docker build -t ipython/notebook:onbuild notebook-onbuild
+
 scipystack: scipystack/Dockerfile
 		docker build -t ipython/scipystack scipystack
 
 scipyserver: scipystack scipyserver/Dockerfile
 		docker build -t ipython/scipyserver scipyserver
 
-.PHONY: pull scipystack scipyserver notebook
+.PHONY: pull scipystack scipyserver notebook notebook-onbuild

--- a/notebook-onbuild/Dockerfile
+++ b/notebook-onbuild/Dockerfile
@@ -1,0 +1,11 @@
+FROM ipython/notebook
+
+ONBUILD COPY apt-dependencies.txt requirements.txt /
+ONBUILD RUN if [ -s /apt-dependencies.txt ]; then \
+              apt-get update -qq \
+              && cat /apt-dependencies.txt | egrep -v '^#' | tr '\n' ' ' | \
+                   DEBIAN_FRONTEND=noninteractive xargs apt-get install -yq --no-install-recommends \
+              && rm -rf /var/lib/apt/lists/* ;\
+            fi \
+         && pip2 install --no-cache-dir -r /requirements.txt \
+         && pip3 install --no-cache-dir -r /requirements.txt

--- a/notebook-onbuild/README.md
+++ b/notebook-onbuild/README.md
@@ -1,0 +1,29 @@
+Build an image with packages from the PyPI
+==========================================
+
+You can build your own image that includes additional packages you need for your task.
+
+For example, to access a MySQL-database with the ORM-framework *SQLAlchemy*, create a directory and put these files into it:
+
+`Dockerfile`
+
+```
+FROM  ipython/notebook:onbuild
+```
+
+`apt-dependencies.txt` (packages from the [Ubuntu-repository](http://packages.ubuntu.com/trusty/))
+
+```
+libmysqlclient-dev
+```
+
+`requirements.txt` (packages from the [Python Package Index](https://pypi.python.org/pypi))
+
+```
+mysqlclient
+SQLAlchemy
+```
+
+Then change into that directory and build the image:
+
+    $ docker build -t myproject .


### PR DESCRIPTION
this adds an onbuild-image for users who need additional Python packages. 

i hope this fits into your release-flow.

could `scipyserver`-users also benfit from it?

another approach to get extra-packages into a notebook-instance could be to move the installation logic to `notebook.sh` and rely on environment-variables.
