### PR TITLE
Deprecation notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 IPython in Docker
 =================
 
+**NOTE: This repository and the associated images on Docker Hub are deprecated. Please see https://github.com/jupyter/docker-stacks for update-to-date images of Project Jupyter assets in Docker images.**
+
 This repository contains the Dockerfiles and shell scripts used by four Docker
 containers:
 


### PR DESCRIPTION
Point to docker-stacks (these images haven't been building properly for a while)
